### PR TITLE
convert to vector before doing calculation in combine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ pom.xml.asc
 .idea/
 *.iml
 .DS_Store
+.cpcache/

--- a/deps.edn
+++ b/deps.edn
@@ -4,7 +4,8 @@
  {
    org.clojure/clojure      {:mvn/version "1.10.1-beta2"}
    aysylu/loom              {:mvn/version "1.0.1"}
-   net.mikera/core.matrix   {:mvn/version "0.62.0"}
+   net.mikera/core.matrix   {:mvn/version "0.63.0"}
+   net.mikera/vectorz-clj {:mvn/version "0.48.0" :provided true}
  }
  :aliases
   {

--- a/src/sigmapi/core.cljc
+++ b/src/sigmapi/core.cljc
@@ -210,9 +210,6 @@
                  tm #?(:clj
                        (cond-> tm (not (instance? Vector tm)) m/matrix)
                        :cljs tm)
-                 v #?(:clj
-                       (cond-> v (not (instance? Vector v)) m/matrix)
-                       :cljs v)
                  q (g tm v)]
              [q rv (mapv pnd nd)]))
          [mat dimz dimz] messages)

--- a/src/sigmapi/core.cljc
+++ b/src/sigmapi/core.cljc
@@ -50,7 +50,8 @@
     [loom.alg :as la]
     [clojure.walk :as walk])
     #?(:cljs (:require-macros
-      [sigmapi.core :refer [fgtree]])))
+              [sigmapi.core :refer [fgtree]])
+       :clj (:import [mikera.vectorz Vector])))
 
 #?(:clj
   (defmacro fgtree [xp]
@@ -206,6 +207,12 @@
            (let [
                  d (get pnd (dim-for-node id))
                  [tm rv nd] (tranz r dimz d last)
+                 tm #?(:clj
+                       (cond-> tm (not (instance? Vector tm)) m/matrix)
+                       :cljs tm)
+                 v #?(:clj
+                       (cond-> v (not (instance? Vector v)) m/matrix)
+                       :cljs v)
                  q (g tm v)]
              [q rv (vec (map pnd nd))]))
          [mat dimz dimz] messages)

--- a/src/sigmapi/core.cljc
+++ b/src/sigmapi/core.cljc
@@ -214,7 +214,7 @@
                        (cond-> v (not (instance? Vector v)) m/matrix)
                        :cljs v)
                  q (g tm v)]
-             [q rv (vec (map pnd nd))]))
+             [q rv (mapv pnd nd)]))
          [mat dimz dimz] messages)
        d (get ddd (dim-for-node to))
        [tm rv nd] (tranz p dimz d first)


### PR DESCRIPTION
In my test I found that inside `learn-step`, `m/add` is applied [here](https://github.com/cambioscience/sigmapi/blob/957e983d74e7976a77e56d7586fbdca460f34b65/src/sigmapi/core.cljc#L209), the first argument `tm` is a Clojure vector which can decrease performance.

Some benchmark test:
```
  (require
    '[clj-async-profiler.core :as prof]
    '[clojure.core.matrix :as m :refer [matrix]])

(def inputs (read-string (slurp "learn-step-inputs.edn")))

  (prof/profile
    (dotimes [_ 10]
      (time (learn-step inputs))))

  ;; with current sigmapi commit

  ;; "Elapsed time: 366.664094 msecs"
  ;; "Elapsed time: 262.04961 msecs"
  ;; "Elapsed time: 250.781755 msecs"
  ;; "Elapsed time: 257.989661 msecs"
  ;; "Elapsed time: 253.044515 msecs"
  ;; "Elapsed time: 255.892414 msecs"
  ;; "Elapsed time: 249.065483 msecs"
  ;; "Elapsed time: 255.923713 msecs"
  ;; "Elapsed time: 255.653309 msecs"
  ;; "Elapsed time: 254.62773 msecs"

  ;; After vectorizing
  ;; "Elapsed time: 224.632673 msecs"
  ;; "Elapsed time: 127.760103 msecs"
  ;; "Elapsed time: 111.955565 msecs"
  ;; "Elapsed time: 108.445775 msecs"
  ;; "Elapsed time: 111.01265 msecs"
  ;; "Elapsed time: 107.563685 msecs"
  ;; "Elapsed time: 105.83532 msecs"
  ;; "Elapsed time: 105.873592 msecs"
  ;; "Elapsed time: 107.711478 msecs"
  ;; "Elapsed time: 111.195091 msecs"

``` 